### PR TITLE
fix: escapable path

### DIFF
--- a/src/shared/yaml-string-builder.spec.ts
+++ b/src/shared/yaml-string-builder.spec.ts
@@ -1,7 +1,7 @@
+import { describe, expect, it } from "@jest/globals";
 import * as YAML from "yaml";
 
 import { YamlStringBuilder } from "./yaml-string-builder";
-import { expect, describe, it } from "@jest/globals";
 
 const yamlFile = `
   name: test_file
@@ -28,6 +28,17 @@ describe("yaml file builder", () => {
     const yaml = YAML.parse(output);
 
     expect(yaml.some.obj.property).toBe("test_value");
+  });
+  it("should should update value at path with escaped colon", () => {
+    const output = new YamlStringBuilder()
+      .haystack(yamlFile)
+      .setValue("some:obj\\:property", "test_value_2")
+      .setValue("some:a:\\b:c\\d\\:e", "test_value_3")
+      .build();
+    const yaml = YAML.parse(output);
+
+    expect(yaml.some["obj:property"]).toBe("test_value_2");
+    expect(yaml.some.a["\\b"]["c\\d:e"]).toBe("test_value_3");
   });
   it("should create value at path", () => {
     const output = new YamlStringBuilder()

--- a/src/shared/yaml-string-builder.ts
+++ b/src/shared/yaml-string-builder.ts
@@ -1,4 +1,4 @@
-import { get, set, unset } from "lodash";
+import { get, set, split, unset } from "lodash";
 import * as YAML from "yaml";
 
 export class YamlStringBuilder {
@@ -10,12 +10,12 @@ export class YamlStringBuilder {
   }
 
   setValue(path: string, value: string) {
-    this.file = set(this.file, path.split(":"), value);
+    this.file = set(this.file, this.makePath(path), value);
     return this;
   }
 
   pushValue(path: string, value: string) {
-    const pathArray = path.split(":");
+    const pathArray = this.makePath(path);
     const existingArray = get(this.file, pathArray) ?? [];
     this.file = set(
       this.file,
@@ -46,5 +46,11 @@ export class YamlStringBuilder {
 
   build() {
     return YAML.stringify(this.file);
+  }
+
+  private makePath(path: string) {
+    return path
+      .split(/(?<!\\):/g)
+      .map((x) => (x.includes("\\:") ? x.replace("\\:", ":") : x));
   }
 }


### PR DESCRIPTION
basically this is a valid yaml object
```yaml
some:thing:
   foo: "bar"
```
previously, this wouldve been set as 
```yaml
some:
  thing:
    foo: "bar"
```
but now the path `some\\:thing:foo` will output the first example